### PR TITLE
refactor: replace useNavigate with Link for page transitions

### DIFF
--- a/src/components/Cart/index.jsx
+++ b/src/components/Cart/index.jsx
@@ -1,26 +1,19 @@
-import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
-import { useBookStore } from "@/store/book"
-import { useNavigate } from 'react-router-dom'
-import BookItem from '../BookItem'
+import { Dialog, DialogBackdrop, DialogPanel, DialogTitle } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { useBookStore } from "@/store/book";
+import { Link } from 'react-router-dom';
+import BookItem from '../BookItem';
 
 const Cart = ({ items, open, onCancel }) => {
-  const { removeCart, clearCart, getTotalPrice  } = useBookStore()
-  const navigate = useNavigate()
-  
-  const changePage = (url) => {
-    navigate(url)
-    onCancel(false)
-    }
+  const { removeCart, clearCart, getTotalPrice } = useBookStore();
 
   const handleRemoveClick = (idx) => {
-    removeCart(idx)
-  }
+    removeCart(idx);
+  };
 
   const handleRemoveAllClick = () => {
-    clearCart()
-  }
-  
+    clearCart();
+  };
 
   return (
     <Dialog open={open} onClose={() => onCancel(false)} className="relative z-10">
@@ -54,14 +47,14 @@ const Cart = ({ items, open, onCancel }) => {
                   {items.length ? (
                     <div className='flex flex-col'>
                       <button className='ml-auto w-32 mt-3 rounded-md border border-transparent bg-gray-400 text-base font-medium text-white shadow-sm hover:bg-gray-300'
-                      onClick={handleRemoveAllClick}
+                        onClick={handleRemoveAllClick}
                       >清空購物車</button>
                       <BookItem books={items} onRemoveClick={handleRemoveClick} />
                     </div>
-                  ) : 
-                  (<div className='flex justify-center'>
-                    <span className='mt-[50%] text-xl text-gray-400'>您的購物車是空的</span>
-                  </div>)}
+                  ) :
+                    (<div className='flex justify-center'>
+                      <span className='mt-[50%] text-xl text-gray-400'>您的購物車是空的</span>
+                    </div>)}
                 </div>
                 <div className="border-t border-gray-200 px-4 py-6 sm:px-6">
                   <div className="flex justify-between text-base font-medium text-gray-900">
@@ -69,19 +62,20 @@ const Cart = ({ items, open, onCancel }) => {
                     <p>NT${getTotalPrice()}</p>
                   </div>
                   <div className="mt-6 flex justify-center">
-                    <button
-                      className="w-full rounded-md border border-transparent bg-blue-500 px-6 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-400"
-                      onClick={() => changePage('/checkout')}
+                    <Link
+                      to="/checkout"
+                      onClick={() => onCancel(false)}
+                      className="block w-full rounded-md border border-transparent bg-blue-500 px-6 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-400 text-center"
                     >
                       結帳
-                    </button>
+                    </Link>
                   </div>
                   <div className="mt-6 flex justify-center text-center text-sm text-gray-500">
                     <button
                       type="button"
                       onClick={() => onCancel(false)}
                       className="font-medium text-blue-600 hover:text-blue-500"
-                      >
+                    >
                       繼續逛逛
                     </button>
                   </div>
@@ -92,7 +86,7 @@ const Cart = ({ items, open, onCancel }) => {
         </div>
       </div>
     </Dialog>
-  )
-}
+  );
+};
 
-export default Cart
+export default Cart;

--- a/src/components/Header/Logo/index.jsx
+++ b/src/components/Header/Logo/index.jsx
@@ -1,23 +1,15 @@
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import logo from "@/images/bookstore-high-resolution-logo-transparent.png";
 
 const Logo = () => {
-  const navigate = useNavigate();
-  const changePage = (url) => {
-    navigate(url);
-  };
-
   return (
-    <div
-      onClick={() => changePage("/")}
-      className="flex items-center cursor-pointer md:mt-4"
-    >
+    <Link to="/" className="flex items-center cursor-pointer md:mt-4">
       <img
         src={logo}
         alt="logo"
         className="w-auto h-auto max-w-52 min-w-52 md:max-w-72"
       />
-    </div>
+    </Link>
   );
 };
 

--- a/src/components/Header/Menu/index.jsx
+++ b/src/components/Header/Menu/index.jsx
@@ -1,18 +1,12 @@
-import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useState } from "react";
 import { Drawer } from "antd";
+import { Link } from "react-router-dom";
 import NavItems from "../NavItem";
 
 const Menu = () => {
-  const navigate = useNavigate();
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
-
-  const changePage = (category) => {
-    navigate(`/books?category=${category}`);
-    setIsOpen(false);
-  };
 
   return (
     <nav className="mr-8">
@@ -45,36 +39,36 @@ const Menu = () => {
         <div className="hidden lg:block">
           <ul className="flex space-x-8">
             <li>
-              <button
-                className="py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
-                onClick={() => changePage("all_categories")}
+              <Link
+                to="/books?category=all_categories"
+                className="inline-flex items-center appearance-none py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
               >
                 {t("all_categories")}
-              </button>
+              </Link>
             </li>
             <li>
-              <button
-                className="py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
-                onClick={() => changePage("ranking")}
+              <Link
+                to="/books?category=ranking"
+                className="inline-flex items-center appearance-none py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
               >
                 {t("ranking")}
-              </button>
+              </Link>
             </li>
             <li>
-              <button
-                className="py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
-                onClick={() => changePage("recommended")}
+              <Link
+                to="/books?category=recommended"
+                className="inline-flex items-center appearance-none py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
               >
                 {t("recommended_for_you")}
-              </button>
+              </Link>
             </li>
             <li>
-              <button
-                className="py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
-                onClick={() => changePage("sitewide")}
+               <Link
+                to="/books?category=sitewide"
+                className="inline-flex items-center appearance-none py-2 px-3 text-gray-600 relative after:absolute after:bg-gray-500 after:bottom-0 after:left-0 after:h-[2px] after:w-full after:origin-bottom-right after:scale-x-0 hover:after:origin-bottom-left hover:after:scale-x-100 after:transition-transform after:ease-in-out after:duration-300"
               >
                 {t("sitewide_events")}
-              </button>
+              </Link>
             </li>
           </ul>
         </div>
@@ -88,44 +82,52 @@ const Menu = () => {
         >
           <ul className="flex flex-col space-y-4">
             <li>
-              <button
-                className="w-full text-left py-2 px-3 text-gray-500 
+              <Link
+                to="/books?category=all_categories"
+                className="inline-flex items-center appearance-none
+                          w-full text-left py-2 px-3 text-gray-500 
                           hover:text-gray-900 hover:bg-gray-50
                           rounded-lg transition-colors duration-200"
-                onClick={() => changePage("all_categories")}
+                onClick={() => setIsOpen(false)}
               >
                 {t("all_categories")}
-              </button>
+              </Link>
             </li>
             <li>
-              <button
-                className="w-full text-left py-2 px-3 text-gray-500 
+              <Link
+                to="/books?category=ranking"
+                className="inline-flex items-center appearance-none
+                            w-full text-left py-2 px-3 text-gray-500 
                           hover:text-gray-900 hover:bg-gray-50
                           rounded-lg transition-colors duration-200"
-                onClick={() => changePage("ranking")}
+                onClick={() => setIsOpen(false)}
               >
                 {t("ranking")}
-              </button>
+              </Link>
             </li>
             <li>
-              <button
-                className="w-full text-left py-2 px-3 text-gray-500 
+              <Link
+                to="/books?category=recommended"
+                className="inline-flex items-center appearance-none
+                            w-full text-left py-2 px-3 text-gray-500 
                           hover:text-gray-900 hover:bg-gray-50
                           rounded-lg transition-colors duration-200"
-                onClick={() => changePage("recommended")}
+                onClick={() => setIsOpen(false)}
               >
                 {t("recommended_for_you")}
-              </button>
+              </Link>
             </li>
             <li>
-              <button
-                className="w-full text-left py-2 px-3 text-gray-500 
+              <Link
+                to="/books?category=sitewide"
+                className="inline-flex items-center appearance-none
+                            w-full text-left py-2 px-3 text-gray-500 
                           hover:text-gray-900 hover:bg-gray-50
                           rounded-lg transition-colors duration-200"
-                onClick={() => changePage("sitewide")}
+                onClick={() => setIsOpen(false)}
               >
                 {t("sitewide_events")}
-              </button>
+              </Link>
             </li>
           </ul>
         </Drawer>

--- a/src/components/Header/NavItem/index.jsx
+++ b/src/components/Header/NavItem/index.jsx
@@ -98,7 +98,9 @@ const NavItems = ({ setIsOpen }) => {
           </Badge>
         </li>
         <li className="cursor-pointer transition-transform hover:scale-110">
-          <Link to="/favorite">
+          <Link to="/favorite"
+            onClick={() => setIsOpen(false)}
+          >
             <FontAwesomeIcon icon={faHeart} />
           </Link>
         </li>

--- a/src/components/Header/NavItem/index.jsx
+++ b/src/components/Header/NavItem/index.jsx
@@ -40,6 +40,10 @@ const NavItems = ({ setIsOpen }) => {
     setIsOpen(false); // 點擊後關閉漢堡選單
   };
 
+  const handleFavoriteClick = () => {
+    setIsOpen(false);
+  };
+
   // 登出事件
   const handleClick = () => {
     localStorage.removeItem("accessToken")
@@ -99,7 +103,9 @@ const NavItems = ({ setIsOpen }) => {
           </Badge>
         </li>
         <li className="cursor-pointer transition-transform hover:scale-110">
-          <Link to="/favorite">
+          <Link to="/favorite"
+            onClick={() => setIsOpen(false)}
+          >
             <FontAwesomeIcon icon={faHeart} />
           </Link>
         </li>

--- a/src/components/Header/NavItem/index.jsx
+++ b/src/components/Header/NavItem/index.jsx
@@ -14,7 +14,6 @@ import { useBookStore } from '@/store/book';
 const NavItems = ({ setIsOpen }) => {
   const { darkMode, setDarkMode } = useUserStore();
   const { cart } = useBookStore();
-
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isCartOpen, setIsCartOpen] = useState(false);
 	const { t } = useTranslation()
@@ -39,11 +38,6 @@ const NavItems = ({ setIsOpen }) => {
     setIsCartOpen(bool)
     setIsOpen(false); // 點擊後關閉漢堡選單
   };
-
-  const handleFavoriteClick = () => {
-    setIsOpen(false);
-  };
-
   // 登出事件
   const handleClick = () => {
     localStorage.removeItem("accessToken")

--- a/src/components/Header/NavItem/index.jsx
+++ b/src/components/Header/NavItem/index.jsx
@@ -6,12 +6,10 @@ import { useUserStore } from "@/store/user"
 import { Modal, message } from 'antd';
 import { useState } from 'react';
 import { userApi } from '@/api/user';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Badge } from 'antd';
 import Cart from '@/components/Cart';
 import { useBookStore } from '@/store/book';
-
-
 
 const NavItems = ({ setIsOpen }) => {
   const { darkMode, setDarkMode } = useUserStore();
@@ -80,13 +78,6 @@ const NavItems = ({ setIsOpen }) => {
     setLanguage(newLanguage) //狀態持久化
   };
 
-  const navigate = useNavigate()
-
-  const changePage = (url) => {
-    navigate(url);
-    setIsOpen(false); // 點擊後關閉漢堡選單
-};
-
   return (
     <>
       <ul className="flex items-center text-xl gap-8">
@@ -96,18 +87,21 @@ const NavItems = ({ setIsOpen }) => {
           <p onClick={() => handleModalOpen(true)}>{t("login")}</p>} 
         </li>
         <li className="cursor-pointer transition-transform hover:scale-110">
-          <FontAwesomeIcon onClick={changeLanguage} icon={faGlobe} /> 
+          <FontAwesomeIcon onClick={changeLanguage} icon={faGlobe} />
         </li>
         <li className="cursor-pointer transition-transform hover:scale-110">
           <FontAwesomeIcon onClick={handleDarkMode} icon={faMoon} /> 
         </li>
         <li className="cursor-pointer transition-transform hover:scale-110">
           <Badge count={cart.length} size='small'>
-            <FontAwesomeIcon className='text-[18px] cart' onClick={() => handleCartOpen(true)} icon={faCartShopping} /> 
+            <FontAwesomeIcon className='text-[18px] cart' onClick={() => handleCartOpen(true)} 
+              icon={faCartShopping} /> 
           </Badge>
         </li>
         <li className="cursor-pointer transition-transform hover:scale-110">
-          <FontAwesomeIcon onClick={() => changePage('/favorite')} icon={faHeart}/>
+          <Link to="/favorite">
+            <FontAwesomeIcon icon={faHeart} />
+          </Link>
         </li>
         <Cart open={isCartOpen} onCancel={setIsCartOpen} items={cart}/>
         <Modal okText={t("login")} cancelText={t("cancel")} open={isModalOpen} onOk={login} 

--- a/src/pages/Books/index.jsx
+++ b/src/pages/Books/index.jsx
@@ -1,7 +1,7 @@
 import BookCard from '@/components/BookCard';
 import { bookApi } from "@/api/book";
 import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from "react-router-dom"
+import { Link, useSearchParams } from "react-router-dom"
 import { useBookStore } from '@/store/book';
 
 const Books = () => {
@@ -10,10 +10,14 @@ const Books = () => {
   const [books, setBooks] = useState([]);
   const [sortOrder, setSortOrder] = useState('');
 
-  const getBooks = async() => {
+  const getBooks = async () => {
+    try {
       const { data } = await bookApi.getBooks();
-      setBooks(data);
-    };
+      setBooks(data); // 存進 store
+    } catch (error) {
+      console.error("Failed to fetch books:", error);
+    }
+  };
 
   const category = searchParams.get('category');
 
@@ -44,19 +48,12 @@ const Books = () => {
     setCart(id, qty);
   };
 
-
   const sortedBooks = filteredBooks.sort((a, b) => {
       if (sortOrder === 'date') {
         return new Date(a.date) - new Date(b.date); 
       }
       return a.title.localeCompare(b.title)
     });
-
-  const navigate = useNavigate()
-
-  const changePage = (url) => {
-    navigate(url)
-  }
 
   useEffect(() => {
     getBooks()
@@ -73,15 +70,18 @@ const Books = () => {
       </div>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 m-4">
         {sortedBooks.map(book => (
-        <BookCard book={book} key={book.id} 
-        onClick={() => changePage(`/book/${book.id}`)} 
-        onFavoriteClick={handleFavoriteClick}  
-        onCartClick={handleCartClick}/>
+        <div key={book.id}>
+          <Link to={`/book/${book.id}`}>
+            <BookCard book={book} 
+            onFavoriteClick={handleFavoriteClick}  
+            onCartClick={handleCartClick}/>
+          </Link>
+        </div>
       ))}
       </div>
     </div>
   </>
   );
-}
+};
 
 export default Books;


### PR DESCRIPTION
Closes #2

## Summary
- 使用 `<Link>` 重構跳轉頁面，取代原本的 `navigate` 

## Notes
- `<Link>` 是建立在 `<a>` 元素上，更符合 HTML 語意
- 保留瀏覽器原生功能，例如  Command+Click 開新分頁、點右鍵可以直接複製目標網址
- 提高程式碼的可讀性

## Testing
- 測試 Command or Ctrl +Click 開啟新分頁
- 點右鍵可以直接複製目標網址
