### PR TITLE
fix: add default fallback for props in NavItems

### DIFF
--- a/src/components/Header/NavItem/index.jsx
+++ b/src/components/Header/NavItem/index.jsx
@@ -11,7 +11,7 @@ import { Badge } from 'antd';
 import Cart from '@/components/Cart';
 import { useBookStore } from '@/store/book';
 
-const NavItems = ({ setIsOpen }) => {
+const NavItems = ({ setIsOpen = () => {} }) => {
   const { darkMode, setDarkMode } = useUserStore();
   const { cart } = useBookStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -104,7 +104,7 @@ const NavItems = ({ setIsOpen }) => {
             <FontAwesomeIcon icon={faHeart} />
           </Link>
         </li>
-        <Cart open={isCartOpen} onCancel={setIsCartOpen} items={cart}/>
+        <Cart open={isCartOpen} onCancel={() => setIsCartOpen(false)} items={cart}/>
         <Modal okText={t("login")} cancelText={t("cancel")} open={isModalOpen} onOk={login} 
           onCancel={handleCancel}>
           <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-16 lg:px-8">


### PR DESCRIPTION
### Summary
將`NavItems` 元件中的 `setIsOpen` props 增加預設值，避免未傳入時造成錯誤

### Notes
- 為 `setIsOpen` 設定預設為 `() => {}`，避免 `TypeError: setIsOpen is not a function`
- 使 `NavItems` 在非 mobile 環境下也能正常使用
- 增加元件彈性與穩定性，讓外部可選擇性地傳入該 props

### Testing
- 確認 `NavItems` 在不傳入 `setIsOpen` 的情況下可正常渲染
- 確認開啟購物車時不會有bug
- Mobile menu 傳入 `setIsOpen` 時仍能正常關閉選單